### PR TITLE
Update peerDependencies to support React 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "license": "Apache-2.0",
   "peerDependencies": {
-    "react": "^16.8 || ^17"
+    "react": "^16.8 || ^17 || ^18"
   },
   "devDependencies": {
     "@babel/core": "^7.18.2",


### PR DESCRIPTION
This is to get rid of the annoying warning that shows when npm installing:

```
 WARN  Issues with peer dependencies found
.
└─┬ @use-cookie-consent/react 0.3.7
  └─┬ @use-cookie-consent/core 0.3.6
    ├── ✕ unmet peer react@"^16.9 || ^17": found 18.2.0
    └── ✕ unmet peer react-dom@"^16.9 || ^17": found 18.2.0
```